### PR TITLE
enable true color and change theme to gruvbox

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -3,7 +3,7 @@
 " Version:     v2.2
 " Email:       ambiguous404@gmail.com
 " Create Time: 2017-08-12
-" Last Modify: 2019-05-23
+" Last Modify: 2019-07-02
 " use za or zr to show fold code !!!
 
 " ============================================================================
@@ -39,9 +39,7 @@ Plugin 'gmarik/vundle'
 " ============================================================================
 " {{{
 " ------------colorschemes------------
-Plugin 'altercation/vim-colors-solarized'
-Plugin 'tomasr/molokai'
-Plugin 'Hanaasagi/suirenka'
+Plugin 'morhetz/gruvbox'
 
 " ------------nerdtree------------
 Plugin 'scrooloose/nerdtree'
@@ -57,7 +55,6 @@ autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTree
 " ------------status line------------
 Plugin 'vim-airline/vim-airline'
 Plugin 'vim-airline/vim-airline-themes'
-let g:airline_theme='luna'
 let g:airline#extensions#tabline#enabled = 1
 
 " ------------tag bar------------
@@ -206,8 +203,8 @@ Plugin 'unblevable/quick-scope'
 let g:qs_highlight_on_keys = ['f', 'F', 't', 'T', ';']
 augroup qs_colors
     autocmd!
-    autocmd ColorScheme * highlight QuickScopePrimary ctermfg=26 cterm=underline
-    autocmd ColorScheme * highlight QuickScopeSecondary ctermfg=155 cterm=underline
+    autocmd ColorScheme * highlight QuickScopePrimary guifg='#5FFFFF' gui=underline ctermfg=26 cterm=underline
+    autocmd ColorScheme * highlight QuickScopeSecondary guifg='#6EF6CC' gui=underline ctermfg=155 cterm=underline
 augroup END
 
 " visualize your Vim undo tree
@@ -421,15 +418,12 @@ set hlsearch
 set incsearch
 
 " colorscheme
+set termguicolors
 set background=dark
-set t_Co=256
 try
-colorscheme suirenka
-" colorscheme molokai
+  colorscheme gruvbox
 catch
 endtry
-
-highlight LineNr ctermfg=224 ctermbg=0
 
 hi CursorLineNR cterm=bold
 

--- a/vimrc
+++ b/vimrc
@@ -40,6 +40,7 @@ Plugin 'gmarik/vundle'
 " {{{
 " ------------colorschemes------------
 Plugin 'morhetz/gruvbox'
+Plugin 'Hanaasagi/suirenka'
 
 " ------------nerdtree------------
 Plugin 'scrooloose/nerdtree'
@@ -418,12 +419,26 @@ set hlsearch
 set incsearch
 
 " colorscheme
-set termguicolors
 set background=dark
-try
-  colorscheme gruvbox
-catch
-endtry
+if has("termguicolors")
+  set termguicolors
+  " see https://github.com/vim/vim/issues/993
+  let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
+  let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
+  try
+    colorscheme gruvbox
+  catch
+  endtry
+else
+  set t_Co=256
+  try
+    colorscheme suirenka
+  catch
+  endtry
+  let g:airline_theme='luna'
+endif
+
+highlight LineNr ctermfg=224 ctermbg=0
 
 hi CursorLineNR cterm=bold
 


### PR DESCRIPTION
- 通过 `set termguicolors` 开启 true color 支持
- https://github.com/Hanaasagi/suirenka 无法在 true color 中正常显示,且配置中有许多插件的颜色配置已经硬编码了
- https://github.com/morhetz/gruvbox 支持 true color 且内置支持一些常见插件的颜色配置,如 airline